### PR TITLE
Add all, any builtins

### DIFF
--- a/src/builtins.h
+++ b/src/builtins.h
@@ -32,6 +32,18 @@ def max(a, b):
 def min(a, b):
     return a < b ? a : b
 
+def all(iterable):
+    for i in iterable:
+        if not i:
+            return False
+    return True
+
+def any(iterable):
+    for i in iterable:
+        if i:
+            return True
+    return False
+
 def sum(iterable):
     res = 0
     for i in iterable:

--- a/tests/_builtin_ty.py
+++ b/tests/_builtin_ty.py
@@ -187,3 +187,15 @@ assert abs(1.0) == 1.0
 assert abs(-1.0) == 1.0
 assert abs(1) == 1
 assert abs(-1) == 1
+
+assert any([1])
+assert any([1,False,True])
+assert not any([])
+assert not any([False])
+
+assert all([])
+assert all([True])
+assert all([True, 1])
+assert not all([False])
+assert not all([True, False])
+assert not all([False, False])


### PR DESCRIPTION
Add `any` and `all` functions to `builtins`

Follows implementation details from Python3 documentation:

https://docs.python.org/3/library/functions.html#all
https://docs.python.org/3/library/functions.html#any



