### PR TITLE
Assert with message

### DIFF
--- a/src/compiler.h
+++ b/src/compiler.h
@@ -887,6 +887,8 @@ __LISTCOMP:
             compile_try_except();
         }else if(match(TK("assert"))){
             EXPR();
+            if (match(TK(","))) EXPR();
+            else emit(OP_LOAD_CONST, co()->add_const(vm->PyStr("")));
             emit(OP_ASSERT);
             consume_end_stmt();
         } else if(match(TK("with"))){

--- a/src/error.h
+++ b/src/error.h
@@ -86,7 +86,7 @@ public:
         StrStream ss;
         if(is_re) ss << "Traceback (most recent call last):\n";
         while(!st.empty()) { ss << st.top() << '\n'; st.pop(); }
-        if (msg.compare("") != 0) ss << type << ": " << msg;
+        if (!msg.empty()) ss << type << ": " << msg;
         else ss << type;
         return ss.str();
     }

--- a/src/error.h
+++ b/src/error.h
@@ -86,7 +86,8 @@ public:
         StrStream ss;
         if(is_re) ss << "Traceback (most recent call last):\n";
         while(!st.empty()) { ss << st.top() << '\n'; st.pop(); }
-        ss << type << ": " << msg;
+        if (msg.compare("") != 0) ss << type << ": " << msg;
+        else ss << type;
         return ss.str();
     }
 };

--- a/src/vm.h
+++ b/src/vm.h
@@ -186,8 +186,10 @@ class VM {
             case OP_LOAD_ELLIPSIS: frame->push(Ellipsis); break;
             case OP_ASSERT:
                 {
+                    PyVar _msg = frame->pop_value(this);
+                    Str msg = PyStr_AS_C(asStr(_msg));
                     PyVar expr = frame->pop_value(this);
-                    if(asBool(expr) != True) _error("AssertionError", "");
+                    if(asBool(expr) != True) _error("AssertionError", msg);
                 } break;
             case OP_EXCEPTION_MATCH:
                 {

--- a/tests/_exception.py
+++ b/tests/_exception.py
@@ -42,3 +42,10 @@ try:
     f1()
 except KeyError:
     print("PASS 04")
+
+
+assert True, "Msg"
+try:
+    assert False, "Msg"
+except AssertionError:
+    print("PASS 05")


### PR DESCRIPTION
Adds support for providing an optional message to an `assert`. A message is any `expr`. 

New behavior: 

```python3

>>> assert False, "Test"
Traceback (most recent call last):
  File "<stdin>", line 1
    assert False, "Test"
AssertionError: Test

>>> x = 1
>>> assert False, x
Traceback (most recent call last):
  File "<stdin>", line 1
    assert False, x
AssertionError: 1

>>> assert False, ""
Traceback (most recent call last):
  File "<stdin>", line 1
    assert False, ""
AssertionError
```

The last example follows Python's behavior. 

I'm not sure if the changes in `compiler.h` are acceptable, I am still trying to get familiar with this codebase. 
Also, I am not sure where the best place is for tests for this. 