### PR TITLE
Fix set __repr__

### DIFF
--- a/src/builtins.h
+++ b/src/builtins.h
@@ -406,8 +406,8 @@ class set:
     def __repr__(self):
         if len(self) == 0:
             return 'set()'
-        return '{'+ ', '.join(self._a.keys()) + '}'
-    
+        return '{'+ ', '.join([repr(i) for i in self._a.keys()]) + '}'
+
     def __iter__(self):
         return self._a.keys()
 )";


### PR DESCRIPTION
`', '.join()` in `set.__repr__` requires the generator object `.keys()` to be made into a `list`. 

Old behavior:
```
pocketpy 0.8.7 (Feb 17 2023, 16:51:06)
https://github.com/blueloveTH/pocketpy
Type "exit()" to exit.
>>> {1}
Traceback (most recent call last):
  File "<stdin>", line 1
    {1}
  File "<builtins>", line 407
    return '{'+ ', '.join(self._a.keys()) + '}'
TypeError: can only join a list or tuple
```