### PR TITLE
[Draft] Set Comprehension

### DIFF
--- a/src/compiler.h
+++ b/src/compiler.h
@@ -567,7 +567,7 @@ __LISTCOMP:
     }
 
     void exprMap() {
-        int _patch = emit(OP_NO_OP);\
+        int _patch = emit(OP_NO_OP);
         int _body_start = co()->codes.size();
         bool parsing_dict = false;
         int size = 0;

--- a/src/vm.h
+++ b/src/vm.h
@@ -217,9 +217,15 @@ public:
                 } break;
             case OP_BUILD_SET:
                 {
-                    PyVar list = PyList(
+                    PyVar list;
+                    if (byte.arg == -1) {
+                        list = frame->pop_value(this);
+                    }
+                    else {
+                        list = PyList(
                         frame->pop_n_values_reversed(this, byte.arg).to_list()
                     );
+                    }
                     PyVar obj = call(builtins->attr("set"), pkpy::one_arg(list));
                     frame->push(obj);
                 } break;
@@ -354,7 +360,7 @@ public:
     bool use_stdio;
     std::ostream* _stdout;
     std::ostream* _stderr;
-    
+
     PyVar builtins;         // builtins module
     PyVar _main;            // __main__ module
 
@@ -454,7 +460,7 @@ public:
             callable = &bm.method;      // get unbound method
             args.extend_self(bm.obj);
         }
-        
+
         if((*callable)->is_type(tp_native_function)){
             const auto& f = OBJ_GET(pkpy::NativeFunc, *callable);
             if(kwargs.size() != 0) TypeError("native_function does not accept keyword arguments");
@@ -491,7 +497,7 @@ public:
                 }
                 if(i < args.size()) TypeError("too many arguments");
             }
-            
+
             for(int i=0; i<kwargs.size(); i+=2){
                 const Str& key = PyStr_AS_C(kwargs[i]);
                 if(!fn->kwArgs.contains(key)){
@@ -666,7 +672,7 @@ public:
             for(int i=0; i<depth; i++) cls = cls->attr(__base__).get();
 
             it = (*root)->attr().find(name);
-            if(it != (*root)->attr().end()) return it->second;        
+            if(it != (*root)->attr().end()) return it->second;
         }else{
             if(obj->is_attr_valid()){
                 it = obj->attr().find(name);
@@ -712,7 +718,7 @@ public:
 
     template<int ARGC>
     void bind_func(Str typeName, Str funcName, NativeFuncRaw fn) {
-        bind_func<ARGC>(_types[typeName], funcName, fn);     
+        bind_func<ARGC>(_types[typeName], funcName, fn);
     }
 
     template<int ARGC>
@@ -869,7 +875,7 @@ public:
     DEF_NATIVE(Range, pkpy::Range, tp_range)
     DEF_NATIVE(Slice, pkpy::Slice, tp_slice)
     DEF_NATIVE(Exception, pkpy::Exception, tp_exception)
-    
+
     // there is only one True/False, so no need to copy them!
     inline bool PyBool_AS_C(const PyVar& obj){return obj == True;}
     inline const PyVar& PyBool(bool value){return value ? True : False;}
@@ -894,7 +900,7 @@ public:
         tp_range = _new_type_object("range");
         tp_module = _new_type_object("module");
         tp_ref = _new_type_object("_ref");
-        
+
         tp_function = _new_type_object("function");
         tp_native_function = _new_type_object("native_function");
         tp_native_iterator = _new_type_object("native_iterator");
@@ -913,7 +919,7 @@ public:
 
         setattr(_t(tp_type), __base__, _t(tp_object));
         setattr(_t(tp_object), __base__, None);
-        
+
         for (auto& [name, type] : _types) {
             setattr(type, __name__, PyStr(name));
         }

--- a/tests/_set.py
+++ b/tests/_set.py
@@ -77,3 +77,8 @@ assert {1,2}.issubset({1,2,3})
 assert {1,2,3}.issuperset({1,2})
 assert {1,2,3}.isdisjoint({4,5,6})
 assert not {1,2,3}.isdisjoint({2,3,4})
+
+x = {i for i in range(3)}
+assert x == {0,1,2}
+x = {i for i in range(3) if i > 0}
+assert x == {1,2}


### PR DESCRIPTION
Given that Set comprehensions are on the roadmap, I thought I would take a shot. 

The implementation directly copies list comprehensions, by issuing `OP_LIST_APPEND` for each element of the set comprehension, and then taking the overall list object and calling `set()` on it. 

The way we distinguish if `OP_BUILD_SET` should expect a pre-made list is by issuing the `ARGC` value of `-1` to it, since we don't count the args while we collect them. Not sure how you feel about that approach. 

Also, this can be refactored to join the __LISTCOMP and __SETCOMP implementations into a common one. 