### PR TITLE
Don't call std::sort on sorted vector

### DIFF
--- a/src/namedict.h
+++ b/src/namedict.h
@@ -30,7 +30,6 @@ namespace pkpy{
             }
             float find_hit_score = indices.size() / (float)keys.size();
             std::vector<uint32_t> indices_vec(indices.begin(), indices.end());
-            std::sort(indices_vec.begin(), indices_vec.end());
             float find_miss_score = indices.size();
             for(int j=1; j<indices_vec.size(); j++){
                 int gap = indices_vec[j] - indices_vec[j-1];


### PR DESCRIPTION
std::set is already kept in sorted order.

I ran this on a small Python file I had lying around:

```python
def foo(x):
    if x:
        return -1
    return -1

import dis
dis.dis(foo)
print(foo(3))
```

and got a 4% instruction count speedup, as measured with Valgrind.

Before: 32200626
After: 30911255


Separately, I noticed that `find_perfect_hash_seed` takes ~70% of the runtime of executing the file. Half of that comes from `CodeObject::optimize` and a little less than half comes from `VM::init_builtin_types`. I wonder if this could be reduced.

![image](https://user-images.githubusercontent.com/401167/221035432-1fd06500-c1bc-4c79-8a87-2d3f1207e01e.png)
