### PR TITLE
adjusted exceptions to be back to using Exception in c bindings

### DIFF
--- a/c_bindings/pocketpy_c.cpp
+++ b/c_bindings/pocketpy_c.cpp
@@ -13,9 +13,14 @@ using namespace pkpy;
         << "this probably means pocketpy itself has a bug!\n" \
         << e.what() << "\n"; \
         exit(2); \
+    } catch(std::runtime_error& e) { \
+        std::cerr << "ERROR: a std::runtime_error " \
+        << "this probably means pocketpy itself has a bug!\n" \
+        << e.what() << "\n"; \
+        exit(2); \
     } catch(...) { \
-        std::cerr << "ERROR: a unknown exception was thrown " \
-        << "this probably means pocketpy itself has a bug!\n"; \
+        std::cerr << "ERROR: a unknown exception was thrown from " << __func__ \
+        << "\nthis probably means pocketpy itself has a bug!\n"; \
         exit(2); \
     }
 
@@ -302,7 +307,7 @@ bool pkpy_get_global(pkpy_vm* vm_handle, const char* name) {
     if (o == nullptr) {
         o = vm->builtins->attr().try_get(name);
         if (o == nullptr)
-            vm->NameError("could not find requested global");
+            throw Exception("NameError", "could not find requested global");
     }
 
     vm->c_data->push(o);

--- a/c_bindings/test_answers.txt
+++ b/c_bindings/test_answers.txt
@@ -1,6 +1,7 @@
 hello world!
 successfully errored with this message: 
-NameError: name 'could not find requested global' is not defined
+Traceback (most recent call last):
+NameError: could not find requested global
 
 testing int methods
 11
@@ -49,3 +50,14 @@ TypeError: expected 2 positional arguments, but got 0 (x)
 
 testing pushing functions
 12
+successfully errored with this message: 
+Traceback (most recent call last):
+NameError: could not find requested global
+successfully errored with this message: 
+Traceback (most recent call last):
+  File "<c-bound>", line 1
+    raise NameError('testing error throwing from python')
+NameError: testing error throwing from python
+successfully errored with this message: 
+Traceback (most recent call last):
+NameError: could not find requested global


### PR DESCRIPTION
exceptions are currently brittle in their implemenation, there are some uses cases that are not support when throwing exceptions from python and passing through c code.

However the current implementation as it stands will work for the TIC-80 bindings I am working on since they only require fairly shallow bindings without nesting python and c code many times recursively.

I added a test cases that you can uncomment to demonstrate where it breaks, and if a real world project ever needs that functionality we can work out a way to support those cases. 