### PR TITLE
Add bash shebang to .sh scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 python3 prebuild.py
 SRC=$(find src/ -name "*.cpp")
 FLAGS="-std=c++17 -O2 -stdlib=libc++ -Wfatal-errors -Iinclude"

--- a/build_web.sh
+++ b/build_web.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 python3 prebuild.py
 
 rm -rf web/lib

--- a/run_c_binding_test.sh
+++ b/run_c_binding_test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 cd c_bindings
 rm -rf build
 mkdir build

--- a/run_profile.sh
+++ b/run_profile.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 python3 prebuild.py
 SRC=$(find src/ -name "*.cpp")
 clang++ -pg -O1 -std=c++17 -stdlib=libc++ -Wfatal-errors -o main $SRC -Iinclude -ldl

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 python3 prebuild.py
 SRC=$(find src/ -name "*.cpp")
 clang++ -std=c++17 --coverage -O1 -stdlib=libc++ -Wfatal-errors -o main src2/main.cpp $SRC -Iinclude -ldl


### PR DESCRIPTION
Note that not all scripts here use bashisms (or need to use bashisms) - we _could_ switch to using `sh` or `dash` instead of `bash`