### PR TITLE
add FileIO.seek internal facility to seek in current file

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -67,6 +67,14 @@ unsigned char* _default_import_handler(const char* name_p, int name_size, int* o
             return VAR(std::move(b));
         });
 
+        vm->bind_method<1>(type, "seek", [](VM* vm, ArgsView args){
+            FileIO& io = CAST(FileIO&, args[0]);
+            size_t newpos = CAST(size_t, args[1]);
+            if (!fseek(io.fp, newpos, SEEK_SET))
+                return vm->True;
+            return vm->False;
+        });
+
         vm->bind_method<1>(type, "write", [](VM* vm, ArgsView args){
             FileIO& io = CAST(FileIO&, args[0]);
             if(io.is_text()){

--- a/tests/70_file.py
+++ b/tests/70_file.py
@@ -41,9 +41,17 @@ os.remove('123.bin')
 assert not os.path.exists('123.bin')
 
 f = open("123.txt","w+")
+# read 0 sized file
+assert( f.read() == "")
+
+# write, rewind() and read whole back
 f.write("123456")
 f.seek(0)
 assert ( f.read() == "123456" )
+
+f.seek(3)
+assert ( f.read() == "456" )
+
 # cannot test seek(>0) then read() for now
 f.close()
 

--- a/tests/70_file.py
+++ b/tests/70_file.py
@@ -39,3 +39,12 @@ f()
 assert os.path.exists('123.bin')
 os.remove('123.bin')
 assert not os.path.exists('123.bin')
+
+f = open("123.txt","w+")
+f.write("123456")
+f.seek(0)
+assert ( f.read() == "123456" )
+# cannot test seek(>0) then read() for now
+f.close()
+
+os.remove('123.txt')

--- a/tests/70_file.py
+++ b/tests/70_file.py
@@ -52,5 +52,8 @@ assert ( f.read() == "123456" )
 f.seek(3)
 assert ( f.read() == "456" )
 
+# nothing more to read (eof)
+assert( f.read() == "")
+
 f.close()
 os.remove('123.txt')

--- a/tests/70_file.py
+++ b/tests/70_file.py
@@ -52,7 +52,5 @@ assert ( f.read() == "123456" )
 f.seek(3)
 assert ( f.read() == "456" )
 
-# cannot test seek(>0) then read() for now
 f.close()
-
 os.remove('123.txt')


### PR DESCRIPTION
returns True on success, False on underlying OS stdlib fail

This is just a cheap/quick facility for an internal function when PK_ENABLE_OS is enabled and is not meant to be used for/replace a full fledged File implementation.
