### PR TITLE
ensure em_asm template get C++ linkage ( cmake builds )

### DIFF
--- a/include/pocketpy/export.h
+++ b/include/pocketpy/export.h
@@ -5,7 +5,7 @@
     #define PK_EXPORT __declspec(dllexport)
     #define PK_SYS_PLATFORM     0
 #elif __EMSCRIPTEN__
-    #define PK_EXPORT EMSCRIPTEN_KEEPALIVE
+    #define PK_EXPORT
     #define PK_SYS_PLATFORM     1
 #elif __APPLE__
     #include <TargetConditionals.h>

--- a/include/pocketpy/export.h
+++ b/include/pocketpy/export.h
@@ -5,7 +5,6 @@
     #define PK_EXPORT __declspec(dllexport)
     #define PK_SYS_PLATFORM     0
 #elif __EMSCRIPTEN__
-    #include <emscripten.h>
     #define PK_EXPORT EMSCRIPTEN_KEEPALIVE
     #define PK_SYS_PLATFORM     1
 #elif __APPLE__

--- a/include/pocketpy/export.h
+++ b/include/pocketpy/export.h
@@ -31,3 +31,4 @@
     #define PK_EXPORT
     #define PK_SYS_PLATFORM     6
 #endif
+

--- a/include/pocketpy/pocketpy_c.h
+++ b/include/pocketpy/pocketpy_c.h
@@ -2,9 +2,6 @@
 #define POCKETPY_C_H
 
 #ifdef __cplusplus
-#if __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
 extern "C" {
 #endif
 

--- a/include/pocketpy/pocketpy_c.h
+++ b/include/pocketpy/pocketpy_c.h
@@ -2,6 +2,9 @@
 #define POCKETPY_C_H
 
 #ifdef __cplusplus
+#if __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 extern "C" {
 #endif
 


### PR DESCRIPTION
to avoid on recent emsdk (clang upstream)
```
In file included from /opt/python-wasm-sdk/emsdk/upstream/emscripten/cache/sysroot/include/emscripten/emscripten.h:23:
/opt/python-wasm-sdk/emsdk/upstream/emscripten/cache/sysroot/include/emscripten/em_asm.h:151:1: error: templates must have C++ linkage
  151 | template<typename, typename = void> struct __em_asm_sig {};
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```