### PR TITLE
fix: ensure isprint() receives unsigned char to prevent MSVC debug as…

### DIFF
--- a/src/common/sstream.c
+++ b/src/common/sstream.c
@@ -103,7 +103,7 @@ void c11_sbuf__write_quoted(c11_sbuf* self, c11_sv sv, char quote) {
                 if(i + u8bytes > sv.size) u8bytes = 0;  // invalid utf8
                 if(u8bytes <= 1) {
                     // not a valid utf8 char, or ascii
-                    if(!isprint(c)) {
+                    if(!isprint((unsigned char)c)) {
                         unsigned char uc = (unsigned char)c;
                         c11_sbuf__write_cstrn(self, "\\x", 2);
                         c11_sbuf__write_char(self, PK_HEX_TABLE[uc >> 4]);


### PR DESCRIPTION
When using MSVC's debug runtime, character classification functions like isprint() perform range assertions requiring values between -1 and 255.Since signed char can have values below -1, this can trigger assertions.This change ensures isprint() always receives an unsigned char parameter.
