### PR TITLE
Add support for some missing escape sequences

### DIFF
--- a/src/compiler/lexer.c
+++ b/src/compiler/lexer.c
@@ -269,13 +269,20 @@ static Error* _eat_string(Lexer* self, c11_sbuf* buff, char quote, enum StringTy
         }
         if(!is_raw && c == '\\') {
             switch(eatchar_include_newline(self)) {
+                // For the list of available escape sequences see
+                // https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences
                 case '"': c11_sbuf__write_char(buff, '"'); break;
                 case '\'': c11_sbuf__write_char(buff, '\''); break;
                 case '\\': c11_sbuf__write_char(buff, '\\'); break;
                 case 'n': c11_sbuf__write_char(buff, '\n'); break;
                 case 'r': c11_sbuf__write_char(buff, '\r'); break;
                 case 't': c11_sbuf__write_char(buff, '\t'); break;
+                case 'a': c11_sbuf__write_char(buff, '\a'); break;
                 case 'b': c11_sbuf__write_char(buff, '\b'); break;
+                case 'f': c11_sbuf__write_char(buff, '\f'); break;
+                case 'v': c11_sbuf__write_char(buff, '\v'); break;
+                // Special case for the often used \0 while we don't have full support for octal literals.
+                case '0': c11_sbuf__write_char(buff, '\0'); break;
                 case 'x': {
                     char hex[3] = {eatchar(self), eatchar(self), '\0'};
                     int code;

--- a/tests/04_str.py
+++ b/tests/04_str.py
@@ -155,6 +155,12 @@ assert '\x30\x31\x32' == '012'
 assert '\b\b\b' == '\x08\x08\x08'
 assert repr('\x1f\x1e\x1f') == '\'\\x1f\\x1e\\x1f\''
 
+assert '\a' == '\x07'
+assert '\b' == '\x08'
+assert '\f' == '\x0c'
+assert '\v' == '\x0b'
+assert '\0' == '\x00'
+
 a = '123'
 assert a.index('2') == 1
 assert a.index('1') == 0


### PR DESCRIPTION
These are still not all escape sequences, but it now supports

* all single character escapes according to https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences
* `\0` as a special case while there is no full support for octal characters.