### PR TITLE
fix pthreads under windows msys2 mingw

### DIFF
--- a/include/pocketpy/common/threads.h
+++ b/include/pocketpy/common/threads.h
@@ -7,7 +7,7 @@
 #include <stdatomic.h>
 #include <stdbool.h>
 
-#if __EMSCRIPTEN__ || __APPLE__ || __linux__
+#if __EMSCRIPTEN__ || __APPLE__ || __linux__ || __MINGW32__
 #include <pthread.h>
 #define PK_USE_PTHREADS 1
 typedef pthread_t c11_thrd_t;


### PR DESCRIPTION
fix cmake build because of <threads.h> not found

Before:
```sh
FAILED: [code=1] thirdlib/pocketpy-2.1.3/CMakeFiles/pocketpy.dir/Unity/unity_pocketpy_c.c.obj 
D:/Dev/MSYS64/ucrt64/bin/ccache.exe D:\Dev\MSYS64\ucrt64\bin\gcc.exe -DPK_ENABLE_CUSTOM_SNAME=0 -DPK_ENABLE_DETERMINISM=0 -DPK_ENABLE_MIMALLOC=0 -DPK_ENABLE_OS=0 -DPK_ENABLE_THREADS=1 -DPK_ENABLE_WATCHDOG=0 -D_CRT_SECURE_NO_WARNINGS -IG:/Projects/papp/thirdlib/pocketpy-2.1.3/include -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -g -std=gnu11 -fdiagnostics-color=always -MD -MT thirdlib/pocketpy-2.1.3/CMakeFiles/pocketpy.dir/Unity/unity_pocketpy_c.c.obj -MF thirdlib\pocketpy-2.1.3\CMakeFiles\pocketpy.dir\Unity\unity_pocketpy_c.c.obj.d -o thirdlib/pocketpy-2.1.3/CMakeFiles/pocketpy.dir/Unity/unity_pocketpy_c.c.obj -c G:/Projects/papp/build/thirdlib/pocketpy-2.1.3/CMakeFiles/pocketpy.dir/Unity/unity_pocketpy_c.c
In file included from G:/Projects/papp/thirdlib/pocketpy-2.1.3/src/common/name.c:6,
                 from G:/Projects/papp/build/thirdlib/pocketpy-2.1.3/CMakeFiles/pocketpy.dir/Unity/unity_pocketpy_c.c:40:
G:/Projects/papp/thirdlib/pocketpy-2.1.3/include/pocketpy/common/threads.h:16:10: fatal error: threads.h: No such file or directory
   16 | #include <threads.h>
      |          ^~~~~~~~~~~
compilation terminated.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows (MinGW) platform compatibility for thread handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->