### PR TITLE
Fix amalgamation script to work with python3-only environments (#444)

### DIFF
--- a/amalgamate.py
+++ b/amalgamate.py
@@ -5,7 +5,7 @@ import sys
 import time
 from typing import List, Dict
 
-assert os.system("python prebuild.py") == 0
+assert os.system(f"{sys.executable} prebuild.py") == 0
 
 ROOT = 'include/pocketpy'
 PUBLIC_HEADERS = ['config.h', 'export.h', 'vmath.h', 'pocketpy.h']

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ if ! type -P clang >/dev/null 2>&1; then
 fi
 
 echo "> Running prebuild.py... "
-python prebuild.py
+command -v python3 >/dev/null 2>&1 && python3 prebuild.py || python prebuild.py
 
 if [ $? -ne 0 ]; then
     echo "prebuild.py failed."

--- a/build_darwin_libs.sh
+++ b/build_darwin_libs.sh
@@ -1,6 +1,9 @@
 set -e
 
-python amalgamate.py
+# Use python3 if available, otherwise fall back to python
+PYTHON=$(command -v python3 >/dev/null 2>&1 && echo python3 || echo python)
+
+$PYTHON amalgamate.py
 
 rm -rf build
 mkdir build
@@ -20,4 +23,4 @@ cmake --build . --config Release
 
 cd ../
 
-python scripts/merge_built_libraries.py build
+$PYTHON scripts/merge_built_libraries.py build

--- a/build_ios_libs.sh
+++ b/build_ios_libs.sh
@@ -1,6 +1,9 @@
 set -e
 
-python amalgamate.py
+# Use python3 if available, otherwise fall back to python
+PYTHON=$(command -v python3 >/dev/null 2>&1 && echo python3 || echo python)
+
+$PYTHON amalgamate.py
 
 rm -rf build
 mkdir build
@@ -27,8 +30,8 @@ cd ../
 
 HEADERS="amalgamated/pocketpy.h"
 
-python scripts/merge_built_libraries.py build/os64
-python scripts/merge_built_libraries.py build/simulatorarm64
+$PYTHON scripts/merge_built_libraries.py build/os64
+$PYTHON scripts/merge_built_libraries.py build/simulatorarm64
 
 xcodebuild -create-xcframework \
     -library build/os64/libpocketpy.a -headers $HEADERS \

--- a/build_web.sh
+++ b/build_web.sh
@@ -1,6 +1,9 @@
 set -e
 
-python prebuild.py
+# Use python3 if available, otherwise fall back to python
+PYTHON=$(command -v python3 >/dev/null 2>&1 && echo python3 || echo python)
+
+$PYTHON prebuild.py
 
 rm -rf web/lib
 mkdir web/lib

--- a/cmake_build.py
+++ b/cmake_build.py
@@ -2,7 +2,7 @@ import os
 import sys
 import shutil
 
-assert os.system("python prebuild.py") == 0
+assert os.system(f"{sys.executable} prebuild.py") == 0
 
 if not os.path.exists("build"):
     os.mkdir("build")

--- a/run_profile.sh
+++ b/run_profile.sh
@@ -1,6 +1,9 @@
 set -e
 
-python prebuild.py
+# Use python3 if available, otherwise fall back to python
+PYTHON=$(command -v python3 >/dev/null 2>&1 && echo python3 || echo python)
+
+$PYTHON prebuild.py
 
 SRC=$(find src/ -name "*.c")
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,12 +1,15 @@
 set -e
 
-python prebuild.py
+# Use python3 if available, otherwise fall back to python
+PYTHON=$(command -v python3 >/dev/null 2>&1 && echo python3 || echo python)
+
+$PYTHON prebuild.py
 
 SRC=$(find src/ -name "*.c")
 
 clang -std=c11 --coverage -O1 -Wfatal-errors -o main src2/main.c $SRC -Iinclude -DPK_ENABLE_OS=1 -lm -ldl -DNDEBUG
 
-python scripts/run_tests.py
+$PYTHON scripts/run_tests.py
 
 # if prev error exit
 if [ $? -ne 0 ]; then

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -2,11 +2,14 @@ import os
 import sys
 import time
 import subprocess
+import shutil
 
 
 def test_file(filepath, cpython=False):
     if cpython:
-        return os.system("python " + filepath) == 0
+        # Use python3 if available, otherwise fall back to python
+        python_cmd = shutil.which("python3") or shutil.which("python") or "python"
+        return os.system(f"{python_cmd} {filepath}") == 0
     if sys.platform == 'win32':
         code = os.system("main.exe " + filepath)
     else:


### PR DESCRIPTION
  Fixes #444
  
  ## Changes
  - Updated Python scripts (`amalgamate.py`, `cmake_build.py`) to use `sys.executable` instead of hardcoded `python` command
  - Updated all shell scripts to prefer `python3` over `python` with automatic fallback
  - Fixed `scripts/run_tests.py` to detect `python3` for CPython benchmarking
  
  ## Testing
  This ensures the amalgamation script works on Linux systems that only have `python3` available and no `python` symlink.
  
  ## Files Changed
  - Python scripts: amalgamate.py, cmake_build.py, scripts/run_tests.py
  - Shell scripts: build.sh, run_tests.sh, run_profile.sh, build_web.sh, build_ios_libs.sh, build_darwin_libs.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system reliability and cross-platform compatibility through intelligent Python interpreter detection. Build scripts now automatically prefer python3 when available, with fallback to python for broader environment support.
  * Optimized build process configuration for enhanced compatibility across systems with multiple Python versions installed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->