### PR TITLE
SECURITY.MD Added

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in pocketpy, please report it responsibly.
+
+Do NOT open a public GitHub issue for security-sensitive bugs.
+
+Instead, report the issue privately by contacting the maintainers with:
+
+- A clear description of the vulnerability
+- Steps to reproduce the issue
+- A minimal proof-of-concept (if possible)
+- Environment details (OS, compiler, version, build flags)
+
+Examples of security issues include:
+
+- Heap-buffer-overflow
+- Stack-buffer-overflow
+- Use-after-free
+- Out-of-bounds read/write
+- Crashes triggered by crafted input
+
+## Response Process
+
+After receiving a report, maintainers may:
+
+1. Confirm and reproduce the issue
+2. Investigate and prepare a fix
+3. Release a patched version
+4. Publicly disclose the issue after it is resolved
+
+Please allow reasonable time for investigation and remediation before public disclosure.
+
+## Supported Versions
+
+Security fixes are typically applied to the latest development version.
+Older versions may not receive patches.


### PR DESCRIPTION
Given the presence of memory safety concerns (e.g., buffer overflows), adding a security policy helps standardize responsible disclosure.