### PR TITLE
Fix C extension module import on Linux

### DIFF
--- a/src/interpreter/dll.c
+++ b/src/interpreter/dll.c
@@ -32,23 +32,23 @@ int load_module_from_dll_desktop_only(const char* path) PY_RAISE PY_RETURN {
     size_t path_len = strlen(path);
     
     // Try path.so
-    path_with_so = (char*)malloc(path_len + 4); // .so + null terminator
+    path_with_so = py_malloc(path_len + 4); // .so + null terminator
     if(path_with_so != NULL) {
         strcpy(path_with_so, path);
         strcat(path_with_so, ".so");
         dll = dlopen(path_with_so, RTLD_LAZY);
-        free(path_with_so);
+        py_free(path_with_so);
     }
     
     // Try libpath.so if path.so didn't work
     if(dll == NULL) {
-        path_with_lib = (char*)malloc(path_len + 7); // lib + .so + null terminator
+        path_with_lib = py_malloc(path_len + 7); // lib + .so + null terminator
         if(path_with_lib != NULL) {
             strcpy(path_with_lib, "lib");
             strcat(path_with_lib, path);
             strcat(path_with_lib, ".so");
             dll = dlopen(path_with_lib, RTLD_LAZY);
-            free(path_with_lib);
+            py_free(path_with_lib);
         }
     }
     


### PR DESCRIPTION
## Description

This PR fixes issue #471 where third-party C extension modules (.so) fail to import on Linux while working on Windows.

## Problem

On Linux, `dlopen("TestPk")` does NOT automatically add `.so` suffix, unlike Windows where `LoadLibraryA("TestPk")` automatically searches for `TestPk.dll`. Additionally, CMake typically generates `libTestPk.so` (with `lib` prefix) instead of `TestPk.so`.

## Solution

Modified `load_module_from_dll_desktop_only()` in `src/interpreter/dll.c` to try multiple library name patterns on Linux:

1. First try: `{path}.so` (e.g., `TestPk.so`)
2. Second try: `lib{path}.so` (e.g., `libTestPk.so`) - CMake default naming
3. Fallback: original path (for explicit paths like `./mylib.so`)

## Changes

- Added `stdlib.h` and `string.h` includes for `malloc`, `strcpy`, `strcat`
- Added logic to construct and try alternative library paths on non-Windows platforms
- Proper memory management with `malloc`/`free`

## Testing

This fix allows the following import patterns to work on Linux:

```python
import TestPk  # Will try TestPk.so, then libTestPk.so
```

Where `TestPk` is a C extension module compiled with:
- `TestPk.so` - direct compilation
- `libTestPk.so` - CMake default output

## Related Issue

Fixes #471
