### PR TITLE
Use python3 if python is unavailable in cmake_build

### DIFF
--- a/cmake_build.py
+++ b/cmake_build.py
@@ -2,7 +2,7 @@ import os
 import sys
 import shutil
 
-assert os.system("python prebuild.py") == 0
+assert os.system("python prebuild.py") == 0 or os.system("python3 prebuild.py") == 0
 
 if not os.path.exists("build"):
     os.mkdir("build")


### PR DESCRIPTION
For macOS/Linux compatibility.