### PR TITLE
Fix assertion failure in py_clearexc when Python function raises exception

### DIFF
--- a/include/pybind11/internal/function.h
+++ b/include/pybind11/internal/function.h
@@ -70,6 +70,7 @@ args_proxy interface<Derived>::operator* () const {
 template <typename Derived>
 template <return_value_policy policy, typename... Args>
 object interface<Derived>::operator() (Args&&... args) const {
+    py_StackRef pc = py_peek(0);  // Save checkpoint BEFORE push
     py_push(ptr());
     py_pushnil();
 
@@ -108,7 +109,16 @@ object interface<Derived>::operator() (Args&&... args) const {
 
     (foreach(std::forward<Args>(args)), ...);
 
-    raise_call<py_vectorcall>(argc, kwargsc);
+    // Don't use raise_call here - it saves checkpoint AFTER push, which causes
+    // an assertion failure in py_clearexc when py_vectorcall fails (because
+    // py_vectorcall pops 2+argc items on both success and failure).
+    // Instead, we save checkpoint BEFORE push and handle error explicitly.
+    if(!py_vectorcall(argc, kwargsc)) {
+        char* what = py_formatexc();
+        object e = object::from_ret();
+        py_clearexc(pc);  // pc is now at or below current sp, assertion safe
+        throw python_error(what, std::move(e));
+    }
 
     return object::from_ret();
 }

--- a/include/pybind11/tests/function.cpp
+++ b/include/pybind11/tests/function.cpp
@@ -410,4 +410,57 @@ TEST_F(PYBIND11_TEST, overload_cast) {
     EXPECT_EVAL_EQ("X().add(1, 2, 3)", 6);
 }
 
+// Test for GitHub issue: calling Python function that raises exception
+// from C++ via py::object::operator() should not crash with assertion failure
+// in py_clearexc. The bug was that raise_call saved the stack checkpoint
+// AFTER pushing callable + nil + args, but py_vectorcall pops 2+argc items
+// on both success and failure, causing the checkpoint to be below the
+// current stack pointer when py_clearexc is called.
+TEST_F(PYBIND11_TEST, vectorcall_exception) {
+    auto m = py::module::__main__();
+
+    // Define a Python function that raises an exception
+    py::exec(R"(
+def raise_error(msg):
+    raise ValueError(msg)
+)");
+
+    // Get the function object
+    py::object raise_error = m.attr("raise_error");
+
+    // Call the function from C++ - this should catch the exception
+    // without crashing due to assertion failure in py_clearexc
+    try {
+        raise_error("test error");
+        FAIL() << "Expected py::python_error to be thrown";
+    } catch (py::python_error& e) {
+        // Expected: we should catch the exception
+        EXPECT_TRUE(e.match(tp_ValueError));
+    }
+
+    // Test with arguments
+    try {
+        py::str msg("error with arg");
+        raise_error(msg);
+        FAIL() << "Expected py::python_error to be thrown";
+    } catch (py::python_error& e) {
+        // Expected: we should catch the exception
+        EXPECT_TRUE(e.match(tp_ValueError));
+    }
+
+    // Test multiple arguments
+    py::exec(R"(
+def raise_error2(a, b, c):
+    raise RuntimeError(f'{a}-{b}-{c}')
+)");
+    py::object raise_error2 = m.attr("raise_error2");
+
+    try {
+        raise_error2(1, 2, 3);
+        FAIL() << "Expected py::python_error to be thrown";
+    } catch (py::python_error& e) {
+        EXPECT_TRUE(e.match(tp_RuntimeError));
+    }
+}
+
 }  // namespace


### PR DESCRIPTION
Problem
When calling a Python function from C++ via pybind11's operator() in a scenario where the Python side raises an exception, the code crashes with an assertion failure:

assertion failed: p0 >= vm->stack.begin && p0 <= vm->stack.sp
This happens in high-frequency C++→Python dispatch scenarios (~60 Hz, hundreds of native calls per tick).

Root Cause
In [operator()](vscode-webview://12n09ruil1c4mtlvl27fmlpvrbgq3k6hkql9eibbvgttaac41j1g/include/pybind11/internal/function.h:72), the original code pushed callable + nil + args to the stack FIRST
Then raise_call<py_vectorcall>() saved a checkpoint via py_peek(0) AFTER the pushes
When py_vectorcall fails, it pops 2+argc items (on both success AND failure per documentation)
The checkpoint is now below the current stack pointer, causing py_clearexc(pc) to fail the assertion
Solution
Save the checkpoint BEFORE pushing items: py_StackRef pc = py_peek(0);
Use explicit error handling instead of raise_call
This ensures pc is at or below current sp when py_clearexc is called
Files Changed
include/pybind11/internal/function.h - Fixed the operator() function
include/pybind11/tests/function.cpp - Added test case vectorcall_exception
Test Case
Added TEST_F(PYBIND11_TEST, vectorcall_exception) which:

Defines a Python function that raises an exception
Calls it from C++ via py::object::operator()
Verifies the exception is caught properly without crashing ..... (#469 )