### PR TITLE
Adding missing header guard to stl.h

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "pybind11.h"
 
 #include <array>


### PR DESCRIPTION
This is a fix to https://github.com/pocketpy/pocketpy/issues/482