### PR TITLE
feat(stdlib): implement missing set update and pop methods

### DIFF
--- a/python/builtins.py
+++ b/python/builtins.py
@@ -190,6 +190,29 @@ class set:
     def __contains__(self, elem):
         return elem in self._a
     
+    def pop(self):
+        if not self._a:
+            raise KeyError('pop from an empty set')
+        # dict.popitem() returns (key, value) tuple
+        k, _ = self._a.popitem()
+        return k
+
+    def difference_update(self, other):
+        for elem in other:
+            self.discard(elem)
+
+    def intersection_update(self, other):
+        to_remove = [elem for elem in self if elem not in other]
+        for elem in to_remove:
+            self.remove(elem)
+
+    def symmetric_difference_update(self, other):
+        for elem in other:
+            if elem in self:
+                self.remove(elem)
+            else:
+                self.add(elem)
+
     def __repr__(self):
         if len(self) == 0:
             return 'set()'

--- a/tests/470_set.py
+++ b/tests/470_set.py
@@ -88,3 +88,19 @@ assert not {1,2,3}.isdisjoint({2,3,4})
 # a = set()
 # b = {*a, 1, 2, 3, *a, *a}
 # assert b == {1, 2, 3}
+a = {1, 2, 3}
+b = a.pop()
+assert b in {1, 2, 3}
+assert len(a) == 2
+
+a = {1, 2, 3}
+a.difference_update({2, 3, 4})
+assert a == {1}
+
+a = {1, 2, 3}
+a.intersection_update({2, 3, 4})
+assert a == {2, 3}
+
+a = {1, 2, 3}
+a.symmetric_difference_update({2, 3, 4})
+assert a == {1, 4}


### PR DESCRIPTION
## Description
This Pull Request implements four missing standard library methods for the `set` class in `python/builtins.py`. These additions bring the `set` implementation closer to CPython 3.x compatibility and provide developers with essential set manipulation tools.

### Implemented Methods
- `set.pop()`: Removes and returns an arbitrary element from the set (implemented using the underlying dictionary's `popitem()`).
- `set.difference_update(other)`: Updates the set, removing elements found in `other`.
- `set.intersection_update(other)`: Updates the set, keeping only elements found in both it and `other`.
- `set.symmetric_difference_update(other)`: Updates the set with the symmetric difference of itself and `other`.

### Changes
- **Modified** `python/builtins.py`: Added the logic for the four methods within the `set` class.
- **Modified** `tests/470_set.py`: Added comprehensive test cases for each of the new methods to ensure correctness.

## Motivation and Context
`pocketpy` aims to provide a lightweight yet standard-compliant Python 3.x experience. The `set` type is a fundamental container, and these common update/pop methods were previously missing. This contribution helps fill those gaps in the standard library.

## How Has This Been Tested?
- Verified the logic by adding specific test cases to the existing `tests/470_set.py` suite.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
