### PR TITLE
Fix typo and improve wording in Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ You have two options to integrate pkpy into your project.
 
 #### Use CMake (Recommended)
 
-Clone the whole repository as a submodule into your project,
-In your CMakelists.txt, add the following lines:
+Clone the whole repository as a submodule into your project. In your `CMakeLists.txt`, add the following lines:
 
 ```cmake
 add_subdirectory(pocketpy)


### PR DESCRIPTION
This PR fixes a typo in the Quick Start section by changing `CMakelists.txt` to `CMakeLists.txt` and improves the sentence wording for clarity.

Because CMakeLists.txt is the official required filename, and CMakelists.txt was a typo that could break setup instructions