### PR TITLE
fix(core): prevent memory leak in py_execo error path

### DIFF
--- a/src/public/CodeExecution.c
+++ b/src/public/CodeExecution.c
@@ -159,7 +159,9 @@ bool py_execo(const void* data, int size, const char* filename, py_Ref module) {
         CodeObject__dtor(&co);
         return ok;
     } else {
-        return RuntimeError("bad code object %s: %s", filename, err);
+        bool ok = RuntimeError("bad code object %s: %s", filename, err);
+        PK_FREE(err);
+        return ok;
     }
 }
 


### PR DESCRIPTION
## Description
Fixes an incremental memory leak in the bytecode deserialization error path.

When `CodeObject__loads` fails inside `py_execo()`, it returns a heap-allocated error string (created via `c11_strdup`). Currently, this string is passed to `RuntimeError` but is never freed before the function returns. If a host application repeatedly fails to load malformed or corrupted bytecode modules, this slowly leaks memory.

This PR stores the boolean result of `RuntimeError`, frees the `err` string via `PK_FREE(err)`, and returns the result to prevent the leak while preserving the exact exception-handling flow.

Fixes #499 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)