### PR TITLE
fix(msgpack): prevent integer overflow in mpack growable writer

### DIFF
--- a/3rd/msgpack/src/mpack.c
+++ b/3rd/msgpack/src/mpack.c
@@ -1164,10 +1164,18 @@ static void mpack_growable_writer_flush(mpack_writer_t* writer, const char* data
             (int)count, (int)mpack_writer_buffer_left(writer), (int)used, (int)size);
 
     // grow to fit the data
-    // TODO: this really needs to correctly test for overflow
-    size_t new_size = size * 2;
-    while (new_size < used + count)
+    if (count > SIZE_MAX - used) {
+        mpack_writer_flag_error(writer, mpack_error_memory);
+        return;
+    }
+    size_t new_size = (size > SIZE_MAX / 2) ? SIZE_MAX : size * 2;
+    while (new_size < used + count) {
+        if (new_size > SIZE_MAX / 2) {
+            new_size = SIZE_MAX;
+            break;
+        }
         new_size *= 2;
+    }
 
     mpack_log("flush growing buffer size from %i to %i\n", (int)size, (int)new_size);
 


### PR DESCRIPTION
### Description

This PR fixes a critical integer overflow vulnerability in the vendored `mpack` library (`3rd/msgpack/src/mpack.c`) that can lead to a Denial of Service (infinite loop) or a Heap Buffer Overflow.

The original `mpack_growable_writer_flush` implementation scaled buffer capacity via a `while` loop without checking for `size_t` wrapping. This resolves the long-standing `// TODO: this really needs to correctly test for overflow` comment present in the codebase.

**Failure Modes Addressed:**
1. **Infinite Loop (Hang):** If a large `count` causes `new_size * 2` to wrap to `0`, the condition `new_size < used + count` remains true indefinitely.
2. **Heap Buffer Overflow:** If `used + count` overflows, the loop terminates prematurely, allocating a buffer that is too small for the subsequent `mpack_memcpy`.

### Changes Made
- Added a strict overflow guard (`count > SIZE_MAX - used`) to prevent addition wrap-around.
- Added a doubling guard (`new_size > SIZE_MAX / 2`) to prevent multiplication wrap-around.
- Clamped maximum growth to `SIZE_MAX` to safely maximize address space utilization before failing out with `mpack_error_memory`.

Fixes #506 