### PR TITLE
Fixed missing '\u85' line separator from str.splitlines patch

### DIFF
--- a/src/common/str.c
+++ b/src/common/str.c
@@ -232,9 +232,12 @@ c11_vector /* T=c11_sv */ c11_sv__splitlines(c11_sv self, bool keepends) {
             eol_size = c11__u8_header(c, false);
             if(c == '\n' || c == '\r' || c == '\v' || c == '\f' || c == '\x1c' || c == '\x1d' || c == '\x1e')
                 break;
-            if(eol_size == 3 && j + 2 < self.size) {
-                int val = c11__u8_value(eol_size, &data[j]);
-                if(val == 0x2028 || val == 0x2029)
+            else if(eol_size == 2 && j + 1 < self.size) {
+                if(c == '\xc2' && data[j+1] == '\x85')
+                    break;
+            }
+            else if(eol_size == 3 && j + 2 < self.size) {
+                if(c == '\xe2' && data[j+1] == '\x80' && (data[j+2] == '\xa8' || data[j+2] == '\xa9'))
                     break;
             }
             j += eol_size;

--- a/tests/043_str_splitlines.py
+++ b/tests/043_str_splitlines.py
@@ -14,19 +14,20 @@ assert ''.splitlines() == []
 assert ''.splitlines(False) == []
 assert ''.splitlines(True) == []
 
-assert '\n'.splitlines() == ['']
-assert '\r'.splitlines() == ['']
-assert '\r\n'.splitlines() == ['']
-assert '\v'.splitlines() == ['']
-assert '\f'.splitlines() == ['']
-assert '\x1c'.splitlines() == ['']
-assert '\x1d'.splitlines() == ['']
-assert '\x1e'.splitlines() == ['']
-assert b'\xe2\x80\xa8'.decode().splitlines() == ['']
-assert b'\xe2\x80\xa9'.decode().splitlines() == ['']
+assert '\n'.splitlines() == ['']                        # Line Feed
+assert '\r'.splitlines() == ['']                        # Carriage return
+assert '\r\n'.splitlines() == ['']                      # Line feed + carriage return
+assert '\v'.splitlines() == ['']                        # Line tabulation
+assert '\f'.splitlines() == ['']                        # Form field
+assert '\x1c'.splitlines() == ['']                      # File separator
+assert '\x1d'.splitlines() == ['']                      # Group separator
+assert '\x1e'.splitlines() == ['']                      # Record separator
+assert b'\xc2\x85'.decode().splitlines() == ['']        # \u85   Next line (C1 control code)
+assert b'\xe2\x80\xa8'.decode().splitlines() == ['']    # \u2028 Unicode line separator
+assert b'\xe2\x80\xa9'.decode().splitlines() == ['']    # \u2029 Unicode paragraph separator
 assert '🥕'.splitlines() == ['🥕']
 
-all_ends = ['\n', '\r', '\r\n', '\v', '\f', '\x1c', '\x1d', '\x1e', b'\xe2\x80\xa8'.decode(), b'\xe2\x80\xa9'.decode()]
+all_ends = ['\n', '\r', '\r\n', '\v', '\f', '\x1c', '\x1d', '\x1e', b'\xc2\x85'.decode(), b'\xe2\x80\xa8'.decode(), b'\xe2\x80\xa9'.decode()]
 for eol in all_ends:
     assert (eol).splitlines() == ['']
     assert (eol).splitlines(False) == ['']


### PR DESCRIPTION
The AI code review was right, I had missed the \u85 separator. Added that, plus the supporting test, and also followed its suggestion about removing the call to ```c11__u8_value``` for efficiency. This is all my code, though, I didn't look at its suggested code or any AI agent to generate anything.