### PR TITLE
Byte iterator bug fix

### DIFF
--- a/include/pocketpy/interpreter/vm.h
+++ b/include/pocketpy/interpreter/vm.h
@@ -156,6 +156,7 @@ py_Type pk_classmethod__register();
 py_Type pk_generator__register();
 py_Type pk_namedict__register();
 py_Type pk_code__register();
+py_Type pk_bytes_iterator__register();
 
 py_GlobalRef pk_builtins__register();
 

--- a/include/pocketpy/pocketpy.h
+++ b/include/pocketpy/pocketpy.h
@@ -843,6 +843,7 @@ enum py_PredefinedType {
     tp_BaseException,
     tp_Exception,
     tp_bytes,
+    tp_bytes_iterator,
     tp_namedict,
     tp_locals,
     tp_code,

--- a/src/bindings/py_str.c
+++ b/src/bindings/py_str.c
@@ -817,6 +817,44 @@ static bool bytes__len__(int argc, py_Ref argv) {
     return true;
 }
 
+
+static bool bytes__iter__(int argc, py_Ref argv) {
+    PY_CHECK_ARGC(1);
+    int* ud = py_newobject(py_retval(), tp_bytes_iterator, 1, sizeof(int));
+    *ud = 0;
+    py_setslot(py_retval(), 0, argv);  
+    return true;
+}
+
+bool bytes_iterator__next__(int argc, py_Ref argv) {
+    PY_CHECK_ARGC(1);
+
+    int* index = py_touserdata(&argv[0]);
+
+    int size;
+    unsigned char* data =
+        py_tobytes(py_getslot(argv,0), &size);
+
+    if(*index == size)
+        return StopIteration();
+
+    py_newint(py_retval(), data[*index]);
+    (*index)++;
+
+    return true;
+}
+
+py_Type pk_bytes_iterator__register() {
+    py_Type type =
+        pk_newtype("bytes_iterator", tp_object, NULL, NULL, false, true);
+
+    py_bindmagic(type, __iter__, pk_wrapper__self);
+    py_bindmagic(type, __next__, bytes_iterator__next__);
+
+    return type;
+}
+
+
 py_Type pk_bytes__register() {
     py_Type type = pk_newtype("bytes", tp_object, NULL, NULL, false, true);
     // no need to dtor because the memory is controlled by the object
@@ -829,6 +867,8 @@ py_Type pk_bytes__register() {
     py_bindmagic(tp_bytes, __add__, bytes__add__);
     py_bindmagic(tp_bytes, __hash__, bytes__hash__);
     py_bindmagic(tp_bytes, __len__, bytes__len__);
+    py_bindmagic(tp_bytes, __iter__, bytes__iter__);
+
 
     py_bindmethod(tp_bytes, "decode", bytes_decode);
     return type;

--- a/src/interpreter/vm.c
+++ b/src/interpreter/vm.c
@@ -156,6 +156,7 @@ void VM__ctor(VM* self) {
     validate(tp_BaseException, pk_BaseException__register());
     validate(tp_Exception, pk_Exception__register());
     validate(tp_bytes, pk_bytes__register());
+    validate(tp_bytes_iterator, pk_bytes_iterator__register());
     validate(tp_namedict, pk_namedict__register());
     validate(tp_locals, pk_newtype("locals", tp_object, NULL, NULL, false, true));
     validate(tp_code, pk_code__register());

--- a/tests/041_str.py
+++ b/tests/041_str.py
@@ -259,3 +259,20 @@ assert f"{(1, 2, 3)}" == "(1, 2, 3)"
 
 assert id('1' * 16) is not None
 assert id('1' * 15) is None
+
+
+# iterator tests for string 
+text = "abc"
+it = iter(text)
+assert iter(it) is it
+
+
+assert next(it) == "a"
+assert next(it) == "b"
+assert next(it) == "c"
+
+try:
+    next(it)
+    exit(1)
+except StopIteration:
+    pass

--- a/tests/290_iter.py
+++ b/tests/290_iter.py
@@ -30,6 +30,9 @@ a = Task(3)
 assert sum(a) == 6
 
 i = iter(Task(5))
+assert iter(i) is i
+
+
 assert next(i) == 1
 assert next(i) == 2
 assert next(i) == 3
@@ -49,4 +52,3 @@ try:
     exit(1)
 except StopIteration:
     pass
-

--- a/tests/460_bytes.py
+++ b/tests/460_bytes.py
@@ -41,3 +41,28 @@ assert a[5:2:-2] == b",l"
 assert bytes() == b''
 assert bytes((65,)) == b'A'
 assert bytes([0, 1, 2, 3]) == b'\x00\x01\x02\x03'
+
+# bytes iterators testing
+assert list(b"abc") == [97, 98, 99]
+
+total = 0
+
+str = "\x01\x02\x03"
+byteStr = str.encode()
+
+for x in byteStr:
+    total += x
+
+assert total == sum(byteStr)
+
+a = iter(byteStr)
+
+assert next(a) == 1
+assert next(a) == 2
+assert next(a) == 3
+
+try:
+    next(a)
+    exit(1)
+except StopIteration:
+    pass

--- a/tests/460_bytes.py
+++ b/tests/460_bytes.py
@@ -45,17 +45,20 @@ assert bytes([0, 1, 2, 3]) == b'\x00\x01\x02\x03'
 # bytes iterators testing
 assert list(b"abc") == [97, 98, 99]
 
+text = "\x01\x02\x03"
+byteStr = text.encode()
+assert byteStr == b'\x01\x02\x03'
+assert list(byteStr) == [1, 2, 3]
+
 total = 0
-
-str = "\x01\x02\x03"
-byteStr = str.encode()
-
 for x in byteStr:
     total += x
 
 assert total == sum(byteStr)
 
 a = iter(byteStr)
+
+assert iter(a) is a
 
 assert next(a) == 1
 assert next(a) == 2


### PR DESCRIPTION
Hello, first and foremost AI disclosure -> I used copilot, previous PRs and discussions to narrow down the issue.
Secondly, the main fix only requires changing 4 files, the 6 files changed in PR are mainly test files to also accommodate for other iterators. 

Approach: 

-  implementation for iterators for default byte type were not present and needed to be implemented.
-  using already implemented string iterators in the (luckily the same) file py_str.c as a reference, learnt about iterators in general and worked my way up from there.
-  ive tried to keep tests concise and consistent with the existing test suite. I also added a few small tests later on for string and list iterators aswell. Mainly for iter(it) == it to match Cpython behaviour.