### PR TITLE
fix(str): zfill should preserve a leading sign

### DIFF
--- a/src/bindings/py_str.c
+++ b/src/bindings/py_str.c
@@ -447,6 +447,12 @@ static bool str_zfill(int argc, py_Ref argv) {
     }
     c11_sbuf buf;
     c11_sbuf__ctor(&buf);
+    // a leading sign is kept in front; the padding goes after it
+    if(self.size > 0 && (self.data[0] == '+' || self.data[0] == '-')) {
+        c11_sbuf__write_char(&buf, self.data[0]);
+        self.data++;
+        self.size--;
+    }
     for(int i = 0; i < delta; i++) {
         c11_sbuf__write_char(&buf, '0');
     }

--- a/tests/041_str.py
+++ b/tests/041_str.py
@@ -112,6 +112,9 @@ assert s2.join( seq ) == "runoob"
 
 assert 'x'.zfill(5) == '0000x'
 assert '568'.zfill(1) == '568'
+assert '-5'.zfill(4) == '-005'
+assert '+5'.zfill(4) == '+005'
+assert '-'.zfill(3) == '-00'
 
 num = 6
 assert str(num) == '6'


### PR DESCRIPTION
`str.zfill` writes the padding zeros before the whole string, so a leading `+` or `-` ends up in the middle of the result instead of staying in front.

| expression | before | after (and CPython) |
|---|---|---|
| `"-5".zfill(4)` | `'00-5'` | `'-005'` |
| `"+5".zfill(4)` | `'00+5'` | `'+005'` |
| `"-".zfill(3)` | `'00-'` | `'-00'` |

CPython inserts the padding after the sign character, and the sign counts toward the requested width. The fix writes the sign first, then the zeros, then the rest of the string. `delta` is still computed before this, so the total length is unchanged.

The existing tests only covered unsigned strings (`'x'.zfill(5)` and `'568'.zfill(1)`), which is why this went unnoticed. Added three asserts next to them.

Checked against CPython 3.12: `"-5"`, `"+5"`, `"5"`, `"-"`, `"-12"`, `""`, `"x"`, `"568"`, `"-0"`, `"--5"` all match, including `"-0".zfill(5)` -> `'-0000'` and `"--5".zfill(5)` -> `'-00-5'` where only the first character counts as a sign. Multibyte strings are unaffected, since the length uses `c11_sv__u8_length` while the sign check is on raw bytes. Full test suite passes.
