### PR TITLE
fix(float): abs(-0.0) should return 0.0

### DIFF
--- a/src/bindings/py_number.c
+++ b/src/bindings/py_number.c
@@ -384,7 +384,7 @@ static bool int__abs__(int argc, py_Ref argv) {
 static bool float__abs__(int argc, py_Ref argv) {
     PY_CHECK_ARGC(1);
     py_f64 val = py_tofloat(&argv[0]);
-    py_newfloat(py_retval(), val < 0 ? -val : val);
+    py_newfloat(py_retval(), dmath_fabs(val));
     return true;
 }
 

--- a/src/common/dmath.c
+++ b/src/common/dmath.c
@@ -701,8 +701,11 @@ double dmath_copysign(double x, double y) {
 	return ux.f;
 }
 
+// https://github.com/kraj/musl/blob/kraj/master/src/math/fabs.c
 double dmath_fabs(double x) {
-    return (x < 0) ? -x : x;
+	union Float64Bits u = { .f = x };
+	u.i &= -1ULL/2;
+	return u.f;
 }
 
 double dmath_ceil(double x) {

--- a/tests/020_float.py
+++ b/tests/020_float.py
@@ -97,6 +97,9 @@ assert 3.4e+3 == 3400.0
 assert abs(1.0) == 1.0
 assert abs(-1.0) == 1.0
 assert abs(0.0) == 0.0
+# abs(-0.0) is 0.0, not -0.0. `==` cannot tell them apart, so check the sign.
+assert str(abs(-0.0)) == '0.0'
+assert str(abs(0.0)) == '0.0'
 
 # import math
 # assert math.isnan(0/0)


### PR DESCRIPTION
`abs(-0.0)` returns `-0.0` instead of `0.0`. `math.fabs(-0.0)` does the same.

```python
abs(-0.0)        # -0.0, CPython gives 0.0
math.fabs(-0.0)  # -0.0, CPython gives 0.0
```

Both come from the idiom `(x < 0) ? -x : x`. Since `-0.0 < 0` is false, the negative zero is returned unchanged. The idiom appears twice, once in `dmath_fabs` and once open-coded in `float__abs__`.

This fixes `dmath_fabs` by clearing the sign bit, the same way `dmath_copysign` just above it works, and makes `float__abs__` call the shared helper instead of repeating the comparison. Fixing only the binding would have left the same bug in the other callers of `dmath_fabs`, which are `math.fabs`, `math.isclose`, and `isclose` in `vmath`.

Checked against CPython 3.12: `abs(-0.0)`, `abs(0.0)`, `abs(-1.5)`, `abs(1.5)`, `abs(-1)`, `abs(0)`, `math.fabs(-0.0)`, and `abs(float('-inf'))` all match.

One note on the tests. `abs(-0.0) == 0.0` is true even with the bug, because `-0.0 == 0.0` under IEEE 754, so an equality assert would pass either way and would not guard anything. The added tests compare `str(...)` instead, which is why they look a little unusual.
